### PR TITLE
Set `AWS_PLUGIN_TARGET` to `/tools/`

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -7,7 +7,7 @@ env:
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
-  AWS_PLUGIN_TARGET: /arduino101load/
+  AWS_PLUGIN_TARGET: /tools/
   ARTIFACT_NAME: dist
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"


### PR DESCRIPTION
Setting `AWS_PLUGIN_TARGET` to `/tools/` should solve access denied errors when the release gets uploaded to the Arduino download servers.