### PR TITLE
Update workflow artifact actions in release workflow

### DIFF
--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        os:
+        task:
           - Windows_32bit
           - Windows_64bit
           - Linux_32bit
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -62,7 +62,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-go-crosscompile-task.yml
+++ b/.github/workflows/release-go-crosscompile-task.yml
@@ -8,7 +8,7 @@ env:
   DIST_DIR: dist
   # The project's folder on Arduino's download server for uploading builds
   AWS_PLUGIN_TARGET: /tools/
-  ARTIFACT_NAME: dist
+  ARTIFACT_PREFIX: dist-
   # See: https://github.com/actions/setup-go/tree/main#supported-version-syntax
   GO_VERSION: "1.17"
 
@@ -23,16 +23,25 @@ jobs:
 
     strategy:
       matrix:
-        task:
-          - Windows_32bit
-          - Windows_64bit
-          - Linux_32bit
-          - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
-          - macOS_64bit
-          - macOS_ARM64
+        os:
+          - task: Windows_32bit
+            artifact-suffix: Windows_32bit
+          - task: Windows_64bit
+            artifact-suffix: Windows_64bit
+          - task: Linux_32bit
+            artifact-suffix: Linux_32bit
+          - task: Linux_64bit
+            artifact-suffix: Linux_64bit
+          - task: Linux_ARMv6
+            artifact-suffix: Linux_ARMv6
+          - task: Linux_ARMv7
+            artifact-suffix: Linux_ARMv7
+          - task: Linux_ARM64
+            artifact-suffix: Linux_ARM64
+          - task: macOS_64bit
+            artifact-suffix: macOS_64bit
+          - task: macOS_ARM64
+            artifact-suffix: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -42,7 +51,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.task == 'Windows_32bit'
+        if: matrix.os.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -62,13 +71,13 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.task }}
+        run: task dist:${{ matrix.os.task }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ env.ARTIFACT_PREFIX }}${{ matrix.os.artifact-suffix }}
           path: ${{ env.DIST_DIR }}
 
   create-release:
@@ -77,10 +86,11 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.ARTIFACT_NAME }}
+          merge-multiple: true
           path: ${{ env.DIST_DIR }}
+          pattern: ${{ env.ARTIFACT_PREFIX }}*
 
       - name: Create checksum file
         working-directory: ${{ env.DIST_DIR}}


### PR DESCRIPTION
The "Release" GitHub Actions workflow generates binaries for a range of target hosts. This is done by using a [job matrix](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) that produces each build in a parallel job. GitHub Actions workflow artifacts are used to transfer the generated files between sequential jobs in the workflow. The [**actions/upload-artifact**](https://github.com/actions/upload-artifact) and [**actions/download-artifact**](https://github.com/actions/download-artifact) actions are used for this purpose.

GitHub made a significant change in the format of the workflow artifacts and has dropped support for the old format used by versions of the actions prior to 4.0.0. This caused the release workflow to fail:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

Due to the change in the artifacts system, some refactoring of the "Release" workflow was required to accommodate the action bumps:

Previously, a single artifact was used for this purpose, with each of the parallel jobs uploading its own generated files to that artifact. However, support for uploading multiple times to a single artifact was [dropped in version 4.0.0 of the "actions/upload-artifact" action](https://github.com/actions/upload-artifact#breaking-changes). So it is now necessary to use a dedicated artifact for each of the builds. These can be downloaded in aggregate by using the [artifact name globbing](https://github.com/actions/download-artifact#inputs:~:text=%3A%0A%0A%20%20%20%20%23%20A-,glob%20pattern,-to%20the%20artifacts) and [merging features](https://github.com/actions/download-artifact#download-multiple-filtered-artifacts-to-the-same-directory) which were introduced in version 4.1.0 of the **actions/download-artifact** action.