### PR TITLE
Configure Windows release tasks to include firmware in generated package

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -29,7 +29,7 @@ tasks:
         go build -o {{.DIST_DIR}}/bin/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}
         cd {{.DIST_DIR}}
         cp -R ../firmwares bin/
-        zip {{.PACKAGE_NAME}} bin/{{.PROJECT_NAME}}.exe bin/firmwares
+        zip -r {{.PACKAGE_NAME}} bin/{{.PROJECT_NAME}}.exe bin/firmwares
     vars:
       PACKAGE_PLATFORM: "Windows_32bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
@@ -44,7 +44,7 @@ tasks:
         go build -o {{.DIST_DIR}}/bin/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}
         cd {{.DIST_DIR}}
         cp -R ../firmwares bin/
-        zip {{.PACKAGE_NAME}} bin/{{.PROJECT_NAME}}.exe bin/firmwares
+        zip -r {{.PACKAGE_NAME}} bin/{{.PROJECT_NAME}}.exe bin/firmwares
     vars:
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"


### PR DESCRIPTION
The tool performs three distinct operations:

- Check the board's operating system version, and if outdated flash the new version.
- Check the board's BLE firmware version, and if outdated flash the new version.
- Flash the user application binary.

For this reason, the release package must contain the operating system and BLE firmware files in addition to the tool executable. These files are stored in subfolders under the `firmwares` folder of the repository.

Previously, the `zip` command used to generate the release packages for Windows hosts was not correctly configured to recurse into the folder when generating the archive. This resulted in the release package only containing an empty folder where the firmware files should have been located. This caused uploads to fail when the target board had an outdated operating system or BLE firmware version.

---

In order to facilitate the review, I performed a test release with the updated tasks in my fork:

Workflow run: https://github.com/per1234/arduino101load/actions/runs/15080113345

Generated release (you can check the content of the generated release packages by downloading them from the release assets): https://github.com/per1234/arduino101load/releases/tag/0.0.0-rc.3

---

Fixes https://github.com/arduino/arduino101load/issues/7